### PR TITLE
Unset the preview region log on examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 This repository contains a collection of samples for Jobs for various use cases.
 
-**Note:** ⚠️ For preview, Cloud Run jobs are available only in the region **`europe-west9`**
-
 ## Samples
 
 |          Sample                          |                     Description                                 |

--- a/invoice-processing-pipeline/README.md
+++ b/invoice-processing-pipeline/README.md
@@ -24,7 +24,7 @@ line.
 
     ```
     GOOGLE_CLOUD_PROJECT=<>
-    GOOGLE_CLOUD_REGION=europe-west9
+    GOOGLE_CLOUD_REGION=us-central1
     ```
 
 * Enable the Cloud Run API, Firestore API, and Cloud Document API.

--- a/invoice-processing-pipeline/processor/deploy.cloudbuild.yaml
+++ b/invoice-processing-pipeline/processor/deploy.cloudbuild.yaml
@@ -29,16 +29,16 @@ steps:
       - |
         gcloud beta run jobs create invoice-processing \
           --image gcr.io/$PROJECT_ID/$_SERVICE_NAME \
-          --region europe-west9 \
+          --region us-central1 \
           --execution-environment gen2
         
         gcloud beta run jobs update invoice-processing \
           --image gcr.io/$PROJECT_ID/$_SERVICE_NAME:$BUILD_ID \
-          --region europe-west9 \
+          --region us-central1 \
           --update-env-vars PROCESSOR_ID=$_PROCESSOR_ID \
           --update-env-vars BUCKET=$_BUCKET 
 
-        gcloud beta run jobs execute invoice-processing --region europe-west9
+        gcloud beta run jobs execute invoice-processing --region us-central1
 
 
 substitutions:

--- a/parallel-processing/deploy-parallel-job.sh
+++ b/parallel-processing/deploy-parallel-job.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 export PROJECT_ID=$(gcloud config get project)
-export REGION=${REGION:=europe-west9} # default us-centra1 region if not defined
+export REGION=${REGION:=us-central1} # default us-central1 region if not defined
 
 JOB_NAME=parallel-job
 NUM_TASKS=10

--- a/screenshot/README.md
+++ b/screenshot/README.md
@@ -7,7 +7,7 @@ See the full [codelab](https://codelabs.developers.google.com/codelabs/cloud-sta
 * Setup gcloud
 ```
 PROJECT_ID=[YOUR-PROJECT-ID]
-REGION=europe-west9
+REGION=us-central1
 gcloud config set core/project $PROJECT_ID
 gcloud config set run/region $REGION
 ```

--- a/user-journeys/replay_every_day.sh
+++ b/user-journeys/replay_every_day.sh
@@ -16,8 +16,8 @@
 
 export PROJECT_ID=$(gcloud config get-value project)
 
-# Choose europe-west9 if REGION is not defined.
-export REGION=${REGION:=europe-west9}
+# Choose us-central1 if REGION is not defined.
+export REGION=${REGION:=us-central1}
 
 echo "Replaying every day"
 

--- a/user-journeys/replay_on_gcp.sh
+++ b/user-journeys/replay_on_gcp.sh
@@ -16,8 +16,8 @@
 
 export PROJECT_ID=$(gcloud config get-value project)
 
-# Choose europe-west9 if REGION is not defined.
-export REGION=${REGION:=europe-west9}
+# Choose us-central1 if REGION is not defined.
+export REGION=${REGION:=us-central1}
 
 echo "Replaying on Google Cloud"
 
@@ -35,7 +35,7 @@ echo "Create a new Artifact Registry container repository"
 gcloud artifacts repositories create containers --repository-format=docker --location=${REGION}
 
 echo "Build this repository into a container image"
-gcloud builds submit -t europe-west9-docker.pkg.dev/${PROJECT_ID}/containers/user-journeys-demo
+gcloud builds submit -t us-central1-docker.pkg.dev/${PROJECT_ID}/containers/user-journeys-demo
 
 echo "Create a service account that has no permission, this will ensure replayed user journeys cannot access any of your Google Cloud resources"
 gcloud iam service-accounts create no-permission --description="No IAM permission"
@@ -43,7 +43,7 @@ gcloud iam service-accounts create no-permission --description="No IAM permissio
 echo "Create a Cloud Run job"
 gcloud beta run jobs create user-journeys-demo \
   --tasks $no_of_journeys \
-  --image europe-west9-docker.pkg.dev/${PROJECT_ID}/containers/user-journeys-demo:latest \
+  --image us-central1-docker.pkg.dev/${PROJECT_ID}/containers/user-journeys-demo:latest \
   --service-account no-permission@${PROJECT_ID}.iam.gserviceaccount.com
 
 echo "Run the Cloud Run job"


### PR DESCRIPTION
There is no longer the requirement to use `europe-west9` only for Cloud Run jobs, so let's revert that to the default `us-central1` default. 