### PR TITLE
Always use latest Puppeteer Docker or use v19+

### DIFF
--- a/user-journeys/Dockerfile
+++ b/user-journeys/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/puppeteer/puppeteer:17.1.3
+FROM ghcr.io/puppeteer/puppeteer:latest
 COPY package*.json ./
 RUN npm ci --omit=dev
 COPY --chown=pptruser:pptruser . .


### PR DESCRIPTION
We fixed a npm cache issue in Puppeteer Docker. (see [#9095](https://github.com/puppeteer/puppeteer/pull/9095/files#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcR16))
Prior to v19, this docker randomly failed due to npm cache permission. User needs to add additional chown on root user to workaround it. See [previous syntax](https://github.com/jecfish/recorder-demo/commit/849aaa6687513e458e9a1f71fcdbbc976f84c397).

The issue is fixed now. This Docker file will work as-is after upgrade to v19+