### PR TITLE
Update README.md

### DIFF
--- a/screenshot/README.md
+++ b/screenshot/README.md
@@ -46,7 +46,6 @@ gcloud projects add-iam-policy-binding $PROJECT_ID \
 ```
 gcloud beta run jobs create screenshot \
   --image=$REGION-docker.pkg.dev/$PROJECT_ID/containers/screenshot:v1 \
-  --args="screenshot.js" \
   --args="https://example.com" \
   --args="https://cloud.google.com" \
   --tasks=2 \


### PR DESCRIPTION
screenshot.js is not a URL. Since screenshot.js is defined in Dockerfile, this commit removes this invalid URL.
![221113881-39de556b-ce3e-4674-ab47-ada15d9aa747](https://user-images.githubusercontent.com/121648127/221121922-9203e960-01d8-464f-9527-81a2c0faa088.png)

https://github.com/GoogleCloudPlatform/jobs-demos/blob/e71b984473447c6916c42d2a78ab2e4a8f832590/screenshot/Dockerfile#L28