### PR TITLE
Change parallel-processing to use env variables

### DIFF
--- a/parallel-processing/process.py
+++ b/parallel-processing/process.py
@@ -19,7 +19,6 @@ import math
 import os
 import time
 
-import click
 import google.auth
 from google.cloud import storage
 
@@ -29,22 +28,22 @@ _, PROJECT_ID = google.auth.default()
 TASK_INDEX = int(os.environ.get("CLOUD_RUN_TASK_INDEX", 0))
 TASK_COUNT = int(os.environ.get("CLOUD_RUN_TASK_COUNT", 1))
 
+INPUT_BUCKET = os.environ.get("INPUT_BUCKET", f"input-{PROJECT_ID}")
+INPUT_FILE = os.environ.get("INPUT_FILE", "input_file.txt")
 
-@click.command()
-@click.argument("input_object")
-@click.option("--input_bucket", default=f"input-{PROJECT_ID}")
-def process(input_object, input_bucket):
+# Process a Cloud Storage object.
+def process():
     method_start = time.time()
 
     # Output useful information about the processing starting.
     print(
         f"Task {TASK_INDEX}: Processing part {TASK_INDEX} of {TASK_COUNT} "
-        f"for gs://{input_bucket}/{input_object}"
+        f"for gs://{INPUT_BUCKET}/{INPUT_FILE}"
     )
 
     # Download the Cloud Storage object
-    bucket = storage_client.bucket(input_bucket)
-    blob = bucket.blob(input_object)
+    bucket = storage_client.bucket(INPUT_BUCKET)
+    blob = bucket.blob(INPUT_FILE)
 
     # Split blog into a list of strings.
     contents = blob.download_as_string().decode("utf-8")

--- a/parallel-processing/requirements.txt
+++ b/parallel-processing/requirements.txt
@@ -1,2 +1,1 @@
-click==8.1.3
 google-cloud-storage==2.3.0


### PR DESCRIPTION
I changed the parallel-processing sample to use env variables instead per Steren's request, so it can be called from Workflows with Eventarc storage events without having to hardcode bucket and file info.